### PR TITLE
Take mutable reference in try_release

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@ impl<'a, 'b> Guard<'a, 'b> {
     /// Releases the lock by deleting the key in memcache.
     ///
     /// Returns `Ok(())` when the lock is successfully released.
-    pub fn try_release(mut self) -> Result<(), LockError> {
+    pub fn try_release(&mut self) -> Result<(), LockError> {
         if !self.released {
             let result = self.lock.release().map_err(Into::into);
             self.released = result.is_ok();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -15,7 +15,7 @@ fn test_lock_release() {
         .with_expiry(1)
         .build()
         .expect("failed to build client");
-    let guard = lock.try_acquire().expect("failed to acquire lock");
+    let mut guard = lock.try_acquire().expect("failed to acquire lock");
     let result = guard.try_release();
     assert!(result.is_ok(), format!("{:?}", result.err()));
     assert_eq!(result.unwrap(), ());
@@ -28,7 +28,7 @@ fn test_long_running_job() {
         .with_expiry(1)
         .build()
         .expect("failed to build client");
-    let guard = lock.try_acquire().expect("failed to acquire lock");
+    let mut guard = lock.try_acquire().expect("failed to acquire lock");
     sleep(Duration::new(2, 0));
     assert_eq!(guard.try_release(), Err(LockError::AlreadyReleased));
 }


### PR DESCRIPTION
Fixes #13 . This is to allow users to retry releasing the lock in case of failures